### PR TITLE
delay folder deletion on Win to avoid race condition

### DIFF
--- a/menuinst/__init__.py
+++ b/menuinst/__init__.py
@@ -8,6 +8,7 @@ import json
 import shutil
 import subprocess
 import tempfile
+import time
 from os.path import abspath, basename, exists, join
 
 from ._version import get_versions
@@ -77,6 +78,7 @@ endlocal
     subprocess.check_call([bat_path])
 
     if not DEBUG:
+        time.sleep(0.5)
         shutil.rmtree(tmp_dir)
 
 


### PR DESCRIPTION
ping @ilanschnell @csoja 

This is a vile hack.  I'm sorry.  I don't know what else to do here.  The issue is that people are not getting menus installed sometimes.  If you enable menuinst.DEBUG, then it always works.  If you comment out the shutil.rmtree, then it always works.  I'm pretty sure this is some awful Windows asynchronous file I/O race condition.  subprocess.check_call **should** absolutely be synchronous, and running the Python should be as well.  There should be no race condition here, but everything I see points to one.  If you have better ideas of how to fix this, I'd be excited to learn a better way.