### PR TITLE
drop support for CSIDL (no win XP support)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,10 +46,11 @@ install:
   - conda install -q conda-build
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
-  - python setup.py install
+  # Hack because we don't find VC for Python right away...  Not used in conda package!!  Just for testing here.
   - set PATH
   - conda build --version
   - copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\amd64\vcvarsamd64.bat"
+  - python setup.py install
 
 
 # Not a .NET project, we build package in the install step instead

--- a/cwp.py
+++ b/cwp.py
@@ -1,13 +1,12 @@
+# this script is used on windows to wrap shortcuts so that they are executed within an environment
+#   It only sets the appropriate prefix PATH entries - it does not actually activate environments
+
 import os
 import sys
 import subprocess
 from os.path import join
-import ctypes, ctypes.wintypes
-import logging
-CSIDL_PERSONAL=5
-SHGFP_TYPE_CURRENT=0
-CSIDL_COMMON_DOCUMENTS=46
-CSIDL_COMMON_STARTMENU=22
+
+from menuinst.knownfolders import FOLDERID, get_folder_path, PathNotFoundException
 
 # call as: python cwp.py PREFIX ARGs...
 
@@ -21,8 +20,10 @@ env['PATH'] = os.path.pathsep.join([
         join(prefix, "Library", "bin"),
         env['PATH'],
 ])
-buf=ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
-if ctypes.windll.shell32.SHGetFolderPathW(0, CSIDL_PERSONAL, 0, SHGFP_TYPE_CURRENT, buf):
-    ctypes.windll.shell32.SHGetFolderPathW(0, CSIDL_COMMON_DOCUMENTS, 0, SHGFP_TYPE_CURRENT, buf)
-os.chdir(buf.value)
+
+try:
+    documents_folder = get_folder_path(FOLDERID.Documents)
+except PathNotFoundException:
+    documents_folder = get_folder_path(FOLDERID.PublicDocuments)
+os.chdir(documents_folder)
 subprocess.call(args, env=env)

--- a/menuinst/knownfolders.py
+++ b/menuinst/knownfolders.py
@@ -182,7 +182,7 @@ def get_folder_path(folder_id, user=None):
 
 if __name__ == '__main__':
     if len(sys.argv) < 2 or sys.argv[1] in ['-?', '/?']:
-        print('python knownpaths.py FOLDERID {current|common}')
+        print('python knownfolders.py FOLDERID {current|common}')
         sys.exit(0)
 
     try:

--- a/menuinst/knownpaths.py
+++ b/menuinst/knownpaths.py
@@ -172,22 +172,13 @@ def get_path(folderid, user_handle=UserHandle.common):
         path = path.decode(codec)
     return path
 
-# wrapper to mimic CSIDL path IDs for Menuinst
-def get_folder_path(csidl_id):
-    user = UserHandle.current
+
+def get_folder_path(folder_id, user=None):
+    if not user:
+        user = UserHandle.current
     # We may want to support modifying the 'Default' user here too for SCCM-based installations.
     # New users created on the machine have their folders created by copying those of 'Default'.
-    folders = {"CSIDL_COMMON_DESKTOPDIRECTORY": FOLDERID.PublicDesktop,
-               "CSIDL_COMMON_PROGRAMS": FOLDERID.CommonPrograms,
-               "CSIDL_COMMON_DOCUMENTS": FOLDERID.PublicDocuments,
-               "CSIDL_PROGRAMS": FOLDERID.Programs,
-               "CSIDL_PERSONAL": FOLDERID.Documents,
-               "CSIDL_PROFILE": FOLDERID.Profile,
-               "CSIDL_APPDATA": FOLDERID.RoamingAppData,
-               "CSIDL_LOCAL_APPDATA": FOLDERID.LocalAppData,
-               "CSIDL_COMMON_APPDATA": FOLDERID.ProgramData,
-    }
-    return get_path(folders[csidl_id], user)
+    return get_path(folder_id, user)
 
 if __name__ == '__main__':
     if len(sys.argv) < 2 or sys.argv[1] in ['-?', '/?']:

--- a/menuinst/win32.py
+++ b/menuinst/win32.py
@@ -11,7 +11,7 @@ from os.path import expanduser, isdir, join, exists
 
 from .utils import rm_empty_dir, rm_rf
 import platform
-from .knownpaths import get_folder_path, FOLDERID
+from .knownfolders import get_folder_path, FOLDERID
 # KNOWNFOLDERID does provide a direct path to Quick luanch.  No additional path necessary.
 from .winshortcut import create_shortcut
 

--- a/menuinst/win32.py
+++ b/menuinst/win32.py
@@ -11,32 +11,22 @@ from os.path import expanduser, isdir, join, exists
 
 from .utils import rm_empty_dir, rm_rf
 import platform
-if platform.release() == "XP":
-    from .csidl import get_folder_path
-    # CSIDL does not provide a direct path to Quick launch.  Start with APPDATA path, go from there.
-    quicklaunch_dirs = ["Microsoft", "Internet Explorer", "Quick Launch"]
-else:
-    from .knownpaths import get_folder_path
-    # KNOWNFOLDERID does provide a direct path to Quick luanch.  No additional path necessary.
-    quicklaunch_dirs = []
+from .knownpaths import get_folder_path, FOLDERID
+# KNOWNFOLDERID does provide a direct path to Quick luanch.  No additional path necessary.
 from .winshortcut import create_shortcut
 
-dirs = {"system": {"desktop": get_folder_path('CSIDL_COMMON_DESKTOPDIRECTORY'),
-                   "start": get_folder_path('CSIDL_COMMON_PROGRAMS'),
-                   "quicklaunch": join(get_folder_path('CSIDL_COMMON_APPDATA'), *quicklaunch_dirs),
-                   "documents": get_folder_path('CSIDL_COMMON_DOCUMENTS'),
-                   "profile": get_folder_path('CSIDL_PROFILE')}}
-try:
-    dirs["user"] = {"desktop": get_folder_path('CSIDL_DESKTOPDIRECTORY'),
-                    "start": get_folder_path('CSIDL_PROGRAMS'),
-                    # LOCAL_APPDATA because that is what the NSIS installer uses
-                    # 'as this is the only place guaranteed to not be backed by a network share
-                    #  or included in a user's roaming profile'
-                    "quicklaunch": join(get_folder_path('CSIDL_LOCAL_APPDATA'), *quicklaunch_dirs),
-                    "documents": get_folder_path('CSIDL_PERSONAL'),
-                    "profile": get_folder_path('CSIDL_PROFILE')}
-except:
-    pass
+dirs = {"system": {"desktop": get_folder_path(FOLDERID.PublicDesktop),
+                   "start": get_folder_path(FOLDERID.CommonPrograms),
+                   "quicklaunch": get_folder_path(FOLDERID.QuickLaunch),
+                   "documents": get_folder_path(FOLDERID.PublicDocuments),
+                   "profile": get_folder_path(FOLDERID.Profile)},
+        "user": {"desktop": get_folder_path(FOLDERID.Desktop),
+                    "start": get_folder_path(FOLDERID.Programs),
+                    "quicklaunch": get_folder_path(FOLDERID.QuickLaunch),
+                    "documents": get_folder_path(FOLDERID.Documents),
+                    "profile": get_folder_path(FOLDERID.Profile)}
+}
+
 
 def quoted(s):
     """


### PR DESCRIPTION
The earlier try...except was silently failing, and our test suite was not passing.  This drops CSIDL (used only on XP, which anaconda no longer supports), and fixes our tests.

CC @ilanschnell @mingwandroid 