### PR TITLE
win32: Disable QuickLaunch for SYSTEM install

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2016-05-26: 1.4.1
+-----------------
+  * Disable 'quicklaunch' shortcuts for SYSTEM user (#33)
+
 2016-05-25: 1.4.0
 -----------------
   * Add license explicitly (BSD 3-clause) (#26)


### PR DESCRIPTION
@msarahan, @ilanschnell, this part got lost in the last commit.

The QuickLaunch folder id doesn't exist for the
'nt authority/system' account and querying it
causes an exception, therefore we cannot add
QuickLaunch entries for this user.