### PR TITLE
move knownfolder import out of cwp to fix import error

### DIFF
--- a/cwp.py
+++ b/cwp.py
@@ -6,24 +6,20 @@ import sys
 import subprocess
 from os.path import join
 
-from menuinst.knownfolders import FOLDERID, get_folder_path, PathNotFoundException
-
 # call as: python cwp.py PREFIX ARGs...
 
 prefix = sys.argv[1]
-args = sys.argv[2:]
+cwd = sys.argv[2]
+args = sys.argv[3:]
 
 env = os.environ.copy()
 env['PATH'] = os.path.pathsep.join([
         prefix,
         join(prefix, "Scripts"),
         join(prefix, "Library", "bin"),
+        join(prefix, "Library", "usr", "bin"),
+        join(prefix, "Library", "mingw-64", "bin"),
         env['PATH'],
 ])
 
-try:
-    documents_folder = get_folder_path(FOLDERID.Documents)
-except PathNotFoundException:
-    documents_folder = get_folder_path(FOLDERID.PublicDocuments)
-os.chdir(documents_folder)
-subprocess.call(args, env=env)
+subprocess.call(args, env=env, cwd=cwd)

--- a/menuinst/win32.py
+++ b/menuinst/win32.py
@@ -10,7 +10,7 @@ import sys
 from os.path import expanduser, isdir, join, exists
 
 from .utils import rm_empty_dir, rm_rf
-from .knownfolders import get_folder_path, FOLDERID
+from .knownfolders import get_folder_path, FOLDERID, PathNotFoundException
 # KNOWNFOLDERID does provide a direct path to Quick luanch.  No additional path necessary.
 from .winshortcut import create_shortcut
 
@@ -138,8 +138,12 @@ class Menu(object):
 
 
 def get_python_args_for_subprocess(prefix, args, cmd):
+    try:
+        documents_folder = get_folder_path(FOLDERID.Documents)
+    except PathNotFoundException:
+        documents_folder = get_folder_path(FOLDERID.PublicDocuments)
     return [quoted(join(unicode_prefix, u'cwp.py')), quoted(prefix),
-            quoted(cmd)] + args
+            quoted(documents_folder), quoted(cmd)] + args
 
 
 def extend_script_args(args, shortcut):


### PR DESCRIPTION
Menuinst was creating invalid shortcuts (perhaps failing to create them) due to import errors with knownfolders.  The problem was that the python running the shortcut is the one in the environment, which loses track of menuinst in PYTHONPATH.

This PR also adds in the MSYS2 paths for shortcuts, which we have been adding elsewhere.

@ilanschnell @mingwandroid - please review

@Maggie-M @csoja this might be what's causing the installers to fail with the menu errors.  The PATH errors are different, though. I'll discuss that elsewhere.