### PR TITLE
cwp.py: Add library/mingw-w64/bin to PATH

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+2016-10-04: 1.4.2
+-----------------
+  * Add Library/mingw-w64/bin to PATH
+
 2016-05-26: 1.4.1
 -----------------
   * Disable 'quicklaunch' shortcuts for SYSTEM user (#33)

--- a/cwp.py
+++ b/cwp.py
@@ -16,6 +16,7 @@ args = sys.argv[2:]
 env = os.environ.copy()
 env['PATH'] = os.path.pathsep.join([
         prefix,
+        join(prefix, "Library", "mingw-w64", "bin"),
         join(prefix, "Scripts"),
         join(prefix, "Library", "bin"),
         env['PATH'],


### PR DESCRIPTION
This fixes https://github.com/ContinuumIO/anaconda-issues/issues/1129, although I would like to know why we cannot activate the root environment instead. IMHO, either activate/deactivate are used exclusively or they are gotten rid of entirely. Any middle ground is just bugs waiting to happen.
