### PR TITLE
fix fallback to user-mode shortcut if elevation denied

### DIFF
--- a/menuinst/__init__.py
+++ b/menuinst/__init__.py
@@ -3,11 +3,11 @@
 # All rights reserved.
 
 from __future__ import absolute_import
+import logging
 import sys
 import json
-import subprocess
-import tempfile
 from os.path import abspath, basename, exists, join
+
 
 from ._version import get_versions
 
@@ -24,7 +24,7 @@ elif sys.platform == 'win32':
     from .win_elevate import isUserAdmin, runAsAdmin
 
 
-def _install(path, remove=False, prefix=sys.prefix):
+def _install(path, remove=False, prefix=sys.prefix, mode=None):
     if abspath(prefix) == abspath(sys.prefix):
         env_name = None
     else:
@@ -37,7 +37,7 @@ def _install(path, remove=False, prefix=sys.prefix):
         menu_name = 'Python-%d.%d' % sys.version_info[:2]
 
     shortcuts = data['menu_items']
-    m = Menu(menu_name, prefix=prefix, env_name=env_name)
+    m = Menu(menu_name, prefix=prefix, env_name=env_name, mode=mode)
     if remove:
         for sc in shortcuts:
             ShortCut(m, sc).remove()
@@ -53,8 +53,15 @@ def install(path, remove=False, prefix=sys.prefix):
     install Menu and shortcuts
     """
     if sys.platform == 'win32' and not exists(join(sys.prefix, '.nonadmin')) and not isUserAdmin():
-        runAsAdmin(['pythonw', '-c',
-                    "import menuinst; menuinst.install(%r, %r, %r)" % (path, bool(remove), prefix)])
+        from pywintypes import error
+        try:
+            runAsAdmin(['pythonw', '-c',
+                        "import menuinst; menuinst.install(%r, %r, %r)" % (
+                            path, bool(remove), prefix)])
+        except error:
+            logging.warn("Insufficient permissions to write menu folder.  "
+                         "Falling back to user location")
+            _install(path, remove, prefix, mode='user')
     else:
         _install(path, remove, prefix)
 

--- a/menuinst/darwin.py
+++ b/menuinst/darwin.py
@@ -12,7 +12,7 @@ from utils import rm_rf
 
 
 class Menu(object):
-    def __init__(self, unused_name, prefix, env_name):
+    def __init__(self, unused_name, prefix, env_name, mode=None):
         self.prefix = prefix
         self.env_name = env_name
     def create(self):

--- a/menuinst/linux.py
+++ b/menuinst/linux.py
@@ -118,7 +118,7 @@ def ensure_menu_file():
 
 class Menu(object):
 
-    def __init__(self, name, prefix, env_name):
+    def __init__(self, name, prefix, env_name, mode=None):
         self.name = name
         self.name_ = name + '_'
         self.entry_fn = '%s.directory' % self.name

--- a/menuinst/win32.py
+++ b/menuinst/win32.py
@@ -9,6 +9,8 @@ import os
 import sys
 from os.path import expanduser, isdir, join, exists
 
+import pywintypes
+
 from .utils import rm_empty_dir, rm_rf
 from .knownfolders import get_folder_path, FOLDERID
 # KNOWNFOLDERID does provide a direct path to Quick luanch.  No additional path necessary.
@@ -105,7 +107,7 @@ class Menu(object):
             used_mode = 'system'
         try:
             self.set_dir(name, prefix, env_name, used_mode)
-        except WindowsError:
+        except (WindowsError, pywintypes.error):
             # We get here if we aren't elevated.  This is different from
             #   permissions: a user can have permission, but elevation is still
             #   required.  If the process isn't elevated, we get the


### PR DESCRIPTION
Replaces exceptions that look like

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "c:\menuinst\menuinst\__init__.py", line 57, in install
    "import menuinst; menuinst.install(%r, %r, %r)" % (path, bool(remove), prefix)])
  File "c:\menuinst\menuinst\win_elevate.py", line 70, in runAsAdmin
    lpParameters=params)
pywintypes.error: (1223, 'ShellExecuteEx', 'The operation was canceled by the user.')
```

with log messages that look like

```
WARNING:root:Insufficient permissions to write menu folder.  Falling back to user location
```

HOWEVER: we don't keep a persistent record of where shortcuts are installed.  This PR handles the single-user with a system-wide install use case well.  It does not handle the multi-user system-wide install case.  In that case, each user can use this to create their shortcuts, but those shortcuts will not be removed if the sysadmin every uninstalls Anaconda/Miniconda.