### PR TITLE
put recursion guard in install func

### DIFF
--- a/menuinst/__init__.py
+++ b/menuinst/__init__.py
@@ -48,17 +48,22 @@ def _install(path, remove=False, prefix=sys.prefix, mode=None):
             ShortCut(m, sc).create()
 
 
-def install(path, remove=False, prefix=sys.prefix):
+def install(path, remove=False, prefix=sys.prefix, recursing=False):
     """
     install Menu and shortcuts
     """
     if sys.platform == 'win32' and not exists(join(sys.prefix, '.nonadmin')) and not isUserAdmin():
         from pywintypes import error
         try:
-            runAsAdmin(['pythonw', '-c',
-                        "import menuinst; menuinst.install(%r, %r, %r)" % (
-                            path, bool(remove), prefix)])
+            if not recursing:
+                retcode = runAsAdmin(['pythonw', '-c',
+                                      "import menuinst; menuinst.install(%r, %r, %r, %r)" % (
+                                          path, bool(remove), prefix, True)])
+            else:
+                retcode = 1
         except error:
+            retcode = 1
+        if retcode != 0:
             logging.warn("Insufficient permissions to write menu folder.  "
                          "Falling back to user location")
             _install(path, remove, prefix, mode='user')


### PR DESCRIPTION
fixes #42 

CC @wulmer @asishm @j-hartshorn @Ritcho @plu2k @jengelman

I have been unable to reproduce the issue locally.  However, I think I understand it thanks to your descriptions.  I believe that this was an infinite loop within the install process.  The code here should prevent that.

If you can test this on your end, I'd be very thankful.