### PR TITLE
Add github CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,49 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  run_test_suite:
+    name: ${{ matrix.os }}-py${{ matrix.PYTHON_VERSION }}
+    runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 30
+    env:
+      DEPENDENCIES: pywin32
+      TEST_DEPENDENCIES: pytest pytest-cov
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows]
+        PYTHON_VERSION: [3.7, 3.8, 3.9]
+
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.PYTHON_VERSION }}
+
+      - shell: bash -l {0}
+        name: Conda info
+        run: |
+          conda info
+          conda list
+
+      - shell: bash -l {0}
+        name: Install dependencies
+        run: |
+          conda install ${{ env.DEPENDENCIES }} ${{ env.TEST_DEPENDENCIES }}
+          conda list
+
+      - shell: bash -l {0}
+        name: Install menuinst
+        run: |
+          pip install -e .
+
+      - shell: bash -l {0}
+        name: Run test suite
+        run: |
+          pytest --cov
+


### PR DESCRIPTION
Run the test suite on github CI; example of a build: https://github.com/ericpre/menuinst/actions.

Would it be possible to tag a release after this PR, so that we can start to use #77 in the conda-forge feedstocks?